### PR TITLE
docs: update README entry file path

### DIFF
--- a/shopping-taxi-app/README.md
+++ b/shopping-taxi-app/README.md
@@ -16,7 +16,7 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/app/page.js`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 


### PR DESCRIPTION
## Summary
- fix outdated entry page path in README

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68933f9483408330b1af5f4801b3ea71