### PR TITLE
Fix clsx argument spread in utility

### DIFF
--- a/shopping-taxi-app/src/lib/utils.ts
+++ b/shopping-taxi-app/src/lib/utils.ts
@@ -2,5 +2,5 @@ import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(...inputs))
 }


### PR DESCRIPTION
## Summary
- fix cn utility to correctly spread class names before merging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933ce5caec83309314c6321ad3a8cd