### PR TITLE
Refactor JWT payload to use id and username

### DIFF
--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/auth.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/auth.controller.ts
@@ -100,6 +100,7 @@ export const login: RequestHandler = async (req, res, next) => {
       return;
     }
 
+    // Token payload carries the user's id and username
     const payload = { id: user.id, username: user.username };
     const accessToken  = signAccessToken(payload);
     const refreshToken = signRefreshToken(payload);
@@ -124,6 +125,7 @@ export const refresh: RequestHandler = async (req, res) => {
   }
 
   try {
+    // Refresh token payload also contains the user's id and username
     const decoded = verifyRefreshToken(token) as AccessTokenPayload;
     const valid = await TokenModel.isTokenValid(decoded.id, token);
     if (!valid) {

--- a/shopping-taxi-app/src/app/backend/server_apis_db/middleware/jwtMiddleware.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/middleware/jwtMiddleware.ts
@@ -3,7 +3,8 @@
 import { RequestHandler } from 'express';
 import { verifyAccessToken, AccessTokenPayload } from '../utils/jwt';
 
-// Make `user` optional so `Request` already fits (no overlap error)
+// Make `user` optional so `Request` already fits (no overlap error).
+// `user` will contain the id and username from the access token.
 export interface AuthenticatedRequest extends Express.Request {
   user?: AccessTokenPayload;
 }
@@ -19,6 +20,7 @@ export const jwtMiddleware: RequestHandler = (req, res, next): void => {
   try {
     const decoded = verifyAccessToken(token) as AccessTokenPayload;
     // Now req already has an optional `user`, so this cast is safe
+    // and contains the user's id and username
     (req as AuthenticatedRequest).user = decoded;
     next();
   } catch {

--- a/shopping-taxi-app/src/app/backend/server_apis_db/utils/jwt.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/utils/jwt.ts
@@ -4,9 +4,9 @@ import ms, { StringValue } from 'ms';
 import jwtConfig from '../config/jwtConfig';
 
 export interface AccessTokenPayload extends jwt.JwtPayload {
-  // add any custom claims here, for example:
-  userId: string;
-  email: string;
+  // add any custom claims here, for example a user's id and username
+  id: string;
+  username: string;
 }
 
 export const signAccessToken = (payload: object): string => {


### PR DESCRIPTION
## Summary
- standardize JWT payload fields to `id` and `username`
- document payload structure in auth flow and middleware

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933f969c488330b5743e7582688018