### PR TITLE
test: add jwt utility tests

### DIFF
--- a/shopping-taxi-app/src/app/utils/__tests__/jwt.test.ts
+++ b/shopping-taxi-app/src/app/utils/__tests__/jwt.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseJwt, isTokenExpired } from '../jwt.ts';
+
+const createToken = (payload: Record<string, unknown>): string => {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+};
+
+test('parseJwt decodes valid JWT payload', () => {
+  const payload = { exp: Math.floor(Date.now() / 1000) + 60, name: 'Alice' };
+  const token = createToken(payload);
+  assert.deepStrictEqual(parseJwt(token), payload);
+});
+
+test('parseJwt returns null for malformed token', () => {
+  assert.strictEqual(parseJwt('malformed.token'), null);
+});
+
+test('isTokenExpired returns false for valid token', () => {
+  const payload = { exp: Math.floor(Date.now() / 1000) + 60 };
+  const token = createToken(payload);
+  assert.strictEqual(isTokenExpired(token), false);
+});
+
+test('isTokenExpired returns true for expired token', () => {
+  const payload = { exp: Math.floor(Date.now() / 1000) - 60 };
+  const token = createToken(payload);
+  assert.strictEqual(isTokenExpired(token), true);
+});
+
+test('isTokenExpired returns true for malformed token', () => {
+  assert.strictEqual(isTokenExpired('malformed.token'), true);
+});


### PR DESCRIPTION
## Summary
- test JWT utilities parseJwt and isTokenExpired
- ensure parseJwt decodes valid tokens and handles malformed ones
- ensure isTokenExpired detects valid, expired, and malformed tokens

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68933fa114948330bd3ab94747630e83