### PR TITLE
feat: add user interface to auth context

### DIFF
--- a/shopping-taxi-app/src/app/context/AuthContext.tsx
+++ b/shopping-taxi-app/src/app/context/AuthContext.tsx
@@ -1,10 +1,15 @@
 'use client';
 import React, { createContext, useState, useEffect, ReactNode } from 'react';
 import { authService } from '@/app/services/authService';
-import { parseJwt } from '@/app/utils/jwt';
+import { parseJwt, JwtPayload } from '@/app/utils/jwt';
 
-interface AuthContextType {
-  user: unknown;
+export interface User extends JwtPayload {
+  id: number;
+  username: string;
+}
+
+export interface AuthContextType {
+  user: User | null;
   login: (data: { email: string; password: string }) => Promise<void>;
   logout: () => Promise<void>;
 }
@@ -12,12 +17,12 @@ interface AuthContextType {
 export const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [user, setUser] = useState<unknown>(null);
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem('accessToken');
     if (token) {
-      const payload = parseJwt(token);
+      const payload = parseJwt(token) as User | null;
       setUser(payload);
     }
   }, []);
@@ -26,7 +31,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const res = await authService.login(data);
     const accessToken = res.data.accessToken;
     localStorage.setItem('accessToken', accessToken);
-    const payload = parseJwt(accessToken);
+    const payload = parseJwt(accessToken) as User | null;
     setUser(payload);
   };
 

--- a/shopping-taxi-app/src/app/hooks/useAuth.ts
+++ b/shopping-taxi-app/src/app/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
-import { AuthContext } from '@/app/context/AuthContext';
+import { AuthContext, AuthContextType } from '@/app/context/AuthContext';
 
-export const useAuth = () => {
+export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);
   if (!context) throw new Error('useAuth must be used within AuthProvider');
   return context;


### PR DESCRIPTION
## Summary
- define User interface for JWT payload
- update AuthContext to use strongly typed User state
- expose AuthContextType in useAuth hook

## Testing
- `npm test` (fails: ENOENT package.json)
- `npm run lint` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_6896244385388330bd2875da9fc6a203