### PR TITLE
refactor: extract shared login form

### DIFF
--- a/shopping-taxi-app/src/app/Frontend/Admin/Auth/Login/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Admin/Auth/Login/page.tsx
@@ -1,86 +1,11 @@
-// src/app/Frontend/Admin/Auth/Login/page.tsx
-"use client";
-import { useState, ChangeEvent, FormEvent } from "react";
-import { useRouter } from "next/navigation";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-import { z } from "zod";
-import { isAxiosError } from "axios";
-import { useAuth } from "@/app/hooks/useAuth";
+import { LoginForm } from '@/components/auth/LoginForm';
 
-const AdminLoginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
-});
 export default function AdminLogin() {
-  const [form, setForm] = useState({ email: "", password: "" });
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<"idle" | "loading">("idle");
-  const router = useRouter();
-  const { login } = useAuth();
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setForm((p) => ({ ...p, [e.target.name]: e.target.value }));
-    setError(null);
-  };
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    const v = AdminLoginSchema.safeParse(form);
-    if (!v.success) {
-      setError(v.error.errors[0].message);
-      return;
-    }
-    setStatus("loading");
-    try {
-      await login({ email: form.email, password: form.password });
-      router.push("/Frontend/Admin/Feed");
-    } catch (err) {
-      setStatus("idle");
-      if (isAxiosError(err))
-        setError(err.response?.data.error ?? "Login failed.");
-      else setError("Login failed.");
-    }
-  };
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md bg-white p-8 shadow-md rounded-xl space-y-6">
-        <h2 className="text-center text-2xl font-bold">Admin Login</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <Input
-            name="email"
-            type="email"
-            placeholder="Email"
-            value={form.email}
-            onChange={handleChange}
-            required
-          />
-          <Input
-            name="password"
-            type="password"
-            placeholder="Password"
-            value={form.password}
-            onChange={handleChange}
-            required
-          />
-          {error && <p className="text-red-500">{error}</p>}
-          <Button
-            type="submit"
-            disabled={status === "loading"}
-            className="w-full"
-          >
-            {status === "loading" ? "Logging in…" : "Log In"}
-          </Button>
-        </form>
-        <p className="text-center text-sm">
-          Don&apos;t have an account?{" "}
-          <Link
-            href="/Frontend/Admin/Auth/Register"
-            className="text-blue-600 hover:underline"
-          >
-            Register
-          </Link>
-        </p>
-      </div>
-    </main>
+    <LoginForm
+      title="Admin Login"
+      redirectPath="/Frontend/Admin/Feed"
+      registerHref="/Frontend/Admin/Auth/Register"
+    />
   );
 }

--- a/shopping-taxi-app/src/app/Frontend/Customer/Auth/Login/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Customer/Auth/Login/page.tsx
@@ -1,82 +1,19 @@
-// src/app/Frontend/Customer/Auth/Login/page.tsx
-'use client';
-import { useState, ChangeEvent, FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { isAxiosError } from 'axios';
-import { z } from 'zod';
-import { useAuth } from '@/app/hooks/useAuth';
+import { LoginForm } from '@/components/auth/LoginForm';
 
-const LoginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
-});
-
-export default function LoginPage() {
-  const [form, setForm] = useState({ email: '', password: '' });
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<'idle' | 'loading'>('idle');
-  const router = useRouter();
-  const { login } = useAuth();
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setForm(p => ({ ...p, [e.target.name]: e.target.value }));
-    setError(null);
-  };
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    const v = LoginSchema.safeParse(form);
-    if (!v.success) {
-      setError(v.error.errors[0].message);
-      return;
-    }
-
-    setStatus('loading');
-    try {
-      await login({ email: form.email, password: form.password });
-      router.push('/Frontend/Customer/Feed');
-    } catch (err: unknown) {
-      setStatus('idle');
-      if (isAxiosError(err)) {
-        setError(err.response?.data.error ?? 'Login failed.');
-      } else {
-        setError('Login failed. Please try again.');
-      }
-    }
-  };
-
+export default function CustomerLogin() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md bg-white p-8 shadow-md rounded-xl space-y-6">
-        <h2 className="text-center text-2xl font-bold">Log in</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <Input name="email" type="email" placeholder="Email" value={form.email} onChange={handleChange} required />
-          <Input name="password" type="password" placeholder="Password" value={form.password} onChange={handleChange} required />
-
-          {error && <p className="text-sm text-red-500">{error}</p>}
-
-          <Button type="submit" disabled={status === 'loading'} className="w-full">
-            {status === 'loading' ? 'Logging in…' : 'Log In'}
-          </Button>
-        </form>
-        <p className="text-center text-sm text-gray-600 space-x-2">
-          <span>Don&apos;t have an account?</span>
-          <Link href="/Frontend/Customer/Auth/Register" className="text-blue-600 hover:underline">
-            Register
-          </Link>
-        </p>
-        <p className="text-center text-sm text-gray-600 space-x-2">
-          <span>Are you a driver?</span>
-          <Link href="/Frontend/Driver/Auth/Login" className="text-blue-600 hover:underline">
-            Driver Login
-          </Link>
-        </p>
-      </div>
-    </main>
+    <LoginForm
+      title="Log in"
+      redirectPath="/Frontend/Customer/Feed"
+      registerHref="/Frontend/Customer/Auth/Register"
+    >
+      <p className="text-center text-sm text-gray-600 space-x-2">
+        <span>Are you a driver?</span>
+        <Link href="/Frontend/Driver/Auth/Login" className="text-blue-600 hover:underline">
+          Driver Login
+        </Link>
+      </p>
+    </LoginForm>
   );
 }

--- a/shopping-taxi-app/src/app/Frontend/Driver/Auth/Login/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Driver/Auth/Login/page.tsx
@@ -1,57 +1,11 @@
-// Driver Login (src/app/Frontend/Driver/Auth/Login/page.tsx)
-'use client';
-import { useState, ChangeEvent, FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import Link from 'next/link';
-import { z } from 'zod';
-import { isAxiosError } from 'axios';
-import { useAuth } from '@/app/hooks/useAuth';
-
-const DriverLoginSchema = z.object({ email: z.string().email(), password: z.string().min(1) });
+import { LoginForm } from '@/components/auth/LoginForm';
 
 export default function DriverLogin() {
-  const [form, setForm] = useState({ email: '', password: '' });
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<'idle' | 'loading'>('idle');
-  const router = useRouter();
-  const { login } = useAuth();
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => { setForm(p => ({ ...p, [e.target.name]: e.target.value })); setError(null); };
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    const v = DriverLoginSchema.safeParse(form);
-    if (!v.success) { setError(v.error.errors[0].message); return; }
-    setStatus('loading');
-    try {
-      await login({ email: form.email, password: form.password });
-      router.push('/Frontend/Driver/Feed');
-    } catch (err: unknown) {
-      setStatus('idle');
-      if (isAxiosError(err)) setError(err.response?.data.error ?? 'Login failed.'); else setError('Login failed.');
-    }
-  };
-
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md bg-white p-8 shadow-md rounded-xl space-y-6">
-        <h2 className="text-center text-2xl font-bold">Driver Login</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <Input name="email" type="email" placeholder="Email" value={form.email} onChange={handleChange} required />
-          <Input name="password" type="password" placeholder="Password" value={form.password} onChange={handleChange} required />
-          {error && <p className="text-red-500">{error}</p>}
-          <Button type="submit" disabled={status==='loading'} className="w-full">
-            {status==='loading' ? 'Logging in…' : 'Log In'}
-          </Button>
-        </form>
-        <p className="text-center text-sm">
-          Don&apos;t have an account?{' '}
-          <Link href="/Frontend/Driver/Auth/Register" className="text-blue-600 hover:underline">
-            Register
-          </Link>
-        </p>
-      </div>
-    </main>
+    <LoginForm
+      title="Driver Login"
+      redirectPath="/Frontend/Driver/Feed"
+      registerHref="/Frontend/Driver/Auth/Register"
+    />
   );
 }

--- a/shopping-taxi-app/src/components/auth/LoginForm.tsx
+++ b/shopping-taxi-app/src/components/auth/LoginForm.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useState, ChangeEvent, FormEvent, ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { z } from 'zod';
+import { isAxiosError } from 'axios';
+import { useAuth } from '@/app/hooks/useAuth';
+
+const LoginSchema = z.object({ email: z.string().email(), password: z.string().min(1) });
+
+interface LoginFormProps {
+  title: string;
+  redirectPath: string;
+  registerHref: string;
+  registerText?: string;
+  children?: ReactNode;
+}
+
+export function LoginForm({ title, redirectPath, registerHref, registerText = 'Register', children }: LoginFormProps) {
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | 'loading'>('idle');
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setForm(p => ({ ...p, [e.target.name]: e.target.value }));
+    setError(null);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const v = LoginSchema.safeParse(form);
+    if (!v.success) {
+      setError(v.error.errors[0].message);
+      return;
+    }
+    setStatus('loading');
+    try {
+      await login({ email: form.email, password: form.password });
+      router.push(redirectPath);
+    } catch (err: unknown) {
+      setStatus('idle');
+      if (isAxiosError(err)) setError(err.response?.data.error ?? 'Login failed.');
+      else setError('Login failed.');
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md bg-white p-8 shadow-md rounded-xl space-y-6">
+        <h2 className="text-center text-2xl font-bold">{title}</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input name="email" type="email" placeholder="Email" value={form.email} onChange={handleChange} required />
+          <Input name="password" type="password" placeholder="Password" value={form.password} onChange={handleChange} required />
+          {error && <p className="text-red-500">{error}</p>}
+          <Button type="submit" disabled={status==='loading'} className="w-full">
+            {status==='loading' ? 'Logging in…' : 'Log In'}
+          </Button>
+        </form>
+        <p className="text-center text-sm">
+          Don&apos;t have an account?{' '}
+          <Link href={registerHref} className="text-blue-600 hover:underline">
+            {registerText}
+          </Link>
+        </p>
+        {children}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize login logic in a reusable `LoginForm` component
- refactor driver, customer, and admin login pages to use `LoginForm`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b20c7d6788330a9145ae61a7e93d0