### PR TITLE
feat: add Google Maps store locator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shopta",
       "version": "1.0.0",
       "dependencies": {
+        "@react-google-maps/api": "^2.20.7",
         "axios": "^1.6.7",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
@@ -558,6 +559,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -825,6 +842,36 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.20.7",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.7.tgz",
+      "integrity": "sha512-ys7uri3V6gjhYZUI43srHzSKDC6/jiKTwHNlwXFTvjeaJE3M3OaYBt9FZKvJs8qnOhL6i6nD1BKJoi1KrnkCkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.16.8",
+        "@googlemaps/markerclusterer": "2.5.3",
+        "@react-google-maps/infobox": "2.20.0",
+        "@react-google-maps/marker-clusterer": "2.20.0",
+        "@types/google.maps": "3.58.1",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
+      "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
+      "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
+      "license": "MIT"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -855,6 +902,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.3.0",
@@ -2195,7 +2248,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2722,6 +2774,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2872,6 +2933,12 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4242,6 +4309,15 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supertest": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "TSX_TSCONFIG=shopping-taxi-app/tsconfig.json tsx shopping-taxi-app/src/app/backend/server_apis_db/server.ts"
   },
   "dependencies": {
+    "@react-google-maps/api": "^2.20.7",
     "axios": "^1.6.7",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",

--- a/shopping-taxi-app/README.md
+++ b/shopping-taxi-app/README.md
@@ -76,6 +76,8 @@ Mapping & Real‑time Updates
 
 Frontend uses Google Maps and Leaflet for displaying store locations and trip paths.
 
+Customers can also search for nearby stores on a Google Map by visiting `/Frontend/Customer/NearbyStores`. This feature relies on the Google Places API, so set `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` in your environment.
+
 Drivers send live location updates via sockets; admins view trip progress in real time.
 
 Configuration & Utilities

--- a/shopping-taxi-app/src/app/Frontend/Customer/Feed/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Customer/Feed/page.tsx
@@ -62,6 +62,13 @@ export default function CustomerFeed() {
         onChange={(e) => setFilter(e.target.value)}
       />
 
+      <button
+        className="mb-4 px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => router.push('/Frontend/Customer/NearbyStores')}
+      >
+        Find Stores Near Me
+      </button>
+
       <StoreList
         stores={filtered}
         onSelect={(id) => router.push(`/Frontend/Customer/StoreDetail/${id}`)}

--- a/shopping-taxi-app/src/app/Frontend/Customer/NearbyStores/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Customer/NearbyStores/page.tsx
@@ -1,0 +1,14 @@
+// Customer Nearby Stores page
+
+'use client';
+import StoreSearchMap from '@/app/components2/StoreSearchMap';
+
+export default function NearbyStores() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Stores Near You</h1>
+      <StoreSearchMap />
+    </main>
+  );
+}
+

--- a/shopping-taxi-app/src/app/components2/StoreSearchMap.tsx
+++ b/shopping-taxi-app/src/app/components2/StoreSearchMap.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { GoogleMap, Marker, useLoadScript } from '@react-google-maps/api';
+import { useCallback, useState } from 'react';
+
+const containerStyle = { width: '100%', height: '400px' };
+const libraries: ('places')[] = ['places'];
+
+interface MarkerInfo {
+  id: string;
+  position: google.maps.LatLngLiteral;
+  name: string;
+}
+
+export default function StoreSearchMap() {
+  const { isLoaded, loadError } = useLoadScript({
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
+    libraries,
+  });
+
+  const [center, setCenter] = useState<google.maps.LatLngLiteral>({
+    lat: 0,
+    lng: 0,
+  });
+  const [markers, setMarkers] = useState<MarkerInfo[]>([]);
+
+  const handleMapLoad = useCallback((map: google.maps.Map) => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        const userLoc = {
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+        };
+        setCenter(userLoc);
+
+        const service = new google.maps.places.PlacesService(map);
+        service.nearbySearch(
+          {
+            location: userLoc,
+            radius: 5000,
+            type: 'store',
+          },
+          (results) => {
+            const newMarkers = (results || [])
+              .filter((r): r is google.maps.places.PlaceResult & { geometry: google.maps.places.PlaceGeometry } => !!r && !!r.geometry && !!r.geometry.location)
+              .map((r) => ({
+                id: r.place_id || Math.random().toString(),
+                position: {
+                  lat: r.geometry!.location!.lat(),
+                  lng: r.geometry!.location!.lng(),
+                },
+                name: r.name || 'Store',
+              }));
+            setMarkers(newMarkers);
+          }
+        );
+      });
+    }
+  }, []);
+
+  if (loadError) return <p>Map failed to load</p>;
+  if (!isLoaded) return <p>Loading map…</p>;
+
+  return (
+    <GoogleMap
+      mapContainerStyle={containerStyle}
+      center={center}
+      zoom={13}
+      onLoad={handleMapLoad}
+    >
+      {markers.map((m) => (
+        <Marker key={m.id} position={m.position} title={m.name} />
+      ))}
+    </GoogleMap>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Google Maps Places-powered component for finding nearby stores
- allow customers to open a map of local stores and navigate from the feed
- document store locator and add `@react-google-maps/api` dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb2048686c8330b20f7086e5cc50d1