### PR TITLE
Add AI routing, promotions, referrals, and analytics services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 .DS_Store
 __pycache__/
 *.pyc
+trip-analytics-service/target/
+trip-analytics-service/.mvn/
+trip-analytics-service/mvnw
+trip-analytics-service/mvnw.cmd

--- a/route_optimizer_service/README.md
+++ b/route_optimizer_service/README.md
@@ -1,8 +1,10 @@
 # Route Optimizer Service
 
-This Python microservice exposes a REST API for suggesting an efficient
-route through a set of stores. The optimization considers proximity,
-user-defined store priorities and expected traffic conditions.
+This Python microservice exposes REST APIs for suggesting efficient
+shopping routes. The optimizer considers proximity, user-defined store
+priorities and expected traffic conditions. An additional AI-assisted
+endpoint layers stochastic search on top of the greedy baseline to
+provide narrative insights alongside the recommended itinerary.
 
 ## Usage
 
@@ -24,6 +26,21 @@ uvicorn route_optimizer_service.main:app --reload
 curl -X POST http://localhost:8000/optimize-route \
     -H "Content-Type: application/json" \
     -d '{"start_lat":0,"start_lng":0,"stores":[{"identifier":"A","lat":0,"lng":1,"store_type":"pharmacy","service_time":5,"priority":1}]}'
+```
+
+To receive the AI-enhanced recommendation and insights, post to
+`/ai-suggest-route` and include optional `iterations` and `random_seed`
+fields:
+
+```bash
+curl -X POST http://localhost:8000/ai-suggest-route \
+    -H "Content-Type: application/json" \
+    -d '{
+          "start_lat":0,
+          "start_lng":0,
+          "iterations":200,
+          "stores":[{"identifier":"A","lat":0,"lng":1,"store_type":"pharmacy","service_time":5,"priority":1}]
+        }'
 ```
 
 The service optionally integrates with the Google Maps Directions API

--- a/route_optimizer_service/ai.py
+++ b/route_optimizer_service/ai.py
@@ -1,0 +1,146 @@
+"""Heuristic AI assistant for shopping route suggestions."""
+from __future__ import annotations
+
+from collections import Counter
+import random
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from .optimizer import Store, optimize_route, travel_time_minutes
+
+
+def _score_route(
+    start: Tuple[float, float],
+    route: Sequence[Store],
+    api_key: Optional[str] = None,
+) -> Tuple[float, float, List[float]]:
+    """Return a composite score, total time and per-leg travel times."""
+
+    current = start
+    travel_segments: List[float] = []
+    total_time = 0.0
+    store_switches = 0
+    previous_type: Optional[str] = None
+
+    for stop in route:
+        travel = travel_time_minutes(current, stop.location, stop.traffic_multiplier, api_key)
+        travel_segments.append(travel)
+        total_time += travel + stop.service_time
+        if previous_type is not None and previous_type != stop.store_type:
+            store_switches += 1
+        previous_type = stop.store_type
+        current = stop.location
+
+    priority_penalty = sum(max(stop.priority - 1, 0) * 2.0 for stop in route)
+    switch_penalty = store_switches * 1.5
+    score = total_time + priority_penalty + switch_penalty
+    return score, total_time, travel_segments
+
+
+def _random_swap(route: Sequence[Store], rng: random.Random) -> List[Store]:
+    """Return a shallow copy of *route* with two stops swapped."""
+
+    if len(route) < 2:
+        return list(route)
+
+    a, b = rng.sample(range(len(route)), 2)
+    swapped = list(route)
+    swapped[a], swapped[b] = swapped[b], swapped[a]
+    return swapped
+
+
+def _build_insights(
+    route: Sequence[Store],
+    travel_segments: Iterable[float],
+    total_time: float,
+) -> List[str]:
+    """Generate human-friendly insights for the given route."""
+
+    if not route:
+        return []
+
+    insights: List[str] = []
+    top_priority = min(route, key=lambda stop: stop.priority)
+    insights.append(
+        (
+            "Prioritizes stop "
+            f"{top_priority.identifier} (priority {top_priority.priority}) to minimise delays."
+        )
+    )
+
+    type_counts = Counter(stop.store_type for stop in route)
+    if type_counts:
+        most_common_type, count = type_counts.most_common(1)[0]
+        if count > 1:
+            insights.append(
+                f"Clusters {count} {most_common_type} stops to reduce context switching on the trip."
+            )
+
+    travel_time = sum(travel_segments)
+    service_time = sum(stop.service_time for stop in route)
+    insights.append(
+        (
+            "Balances travel and in-store time: "
+            f"~{travel_time:.1f} minutes on the road vs {service_time:.1f} minutes in stores."
+        )
+    )
+
+    if total_time:
+        avg_leg = travel_time / len(route)
+        insights.append(
+            f"Average travel per leg is approximately {avg_leg:.1f} minutes across {len(route)} stops."
+        )
+
+    return insights
+
+
+def ai_suggest_route(
+    start: Tuple[float, float],
+    stores: List[Store],
+    api_key: Optional[str] = None,
+    *,
+    iterations: int = 400,
+    random_seed: Optional[int] = None,
+) -> Tuple[List[Store], float, List[str], float]:
+    """Return an AI-assisted route suggestion with narrative insights."""
+
+    if not stores:
+        return [], 0.0, [], 0.0
+
+    if iterations < 1:
+        raise ValueError("iterations must be positive")
+
+    rng = random.Random(random_seed)
+
+    # Start from the greedy baseline and improve with stochastic swaps.
+    baseline_route, baseline_time = optimize_route(start, stores, api_key)
+    best_route: Sequence[Store] = list(baseline_route)
+    best_score, best_total_time, best_segments = _score_route(start, best_route, api_key)
+
+    current_route: Sequence[Store] = list(best_route)
+    current_score = best_score
+    current_segments = list(best_segments)
+
+    for _ in range(iterations):
+        candidate = _random_swap(current_route, rng)
+        candidate_score, candidate_total_time, candidate_segments = _score_route(
+            start, candidate, api_key
+        )
+
+        acceptance_probability = 0.05 if candidate_score > current_score else 1.0
+        if acceptance_probability == 1.0 or rng.random() < acceptance_probability:
+            current_route = candidate
+            current_score = candidate_score
+            current_segments = candidate_segments
+
+            if candidate_score < best_score:
+                best_route = candidate
+                best_score = candidate_score
+                best_total_time = candidate_total_time
+                best_segments = candidate_segments
+
+    insights = _build_insights(best_route, best_segments, best_total_time)
+    average_leg = sum(best_segments) / len(best_segments) if best_segments else 0.0
+    return list(best_route), best_total_time, insights, average_leg
+
+
+__all__ = ["ai_suggest_route"]

--- a/route_optimizer_service/main.py
+++ b/route_optimizer_service/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from .optimizer import Store, optimize_route
+from .ai import ai_suggest_route
 
 
 class StoreInput(BaseModel):
@@ -43,6 +44,21 @@ class OptimizeResponse(BaseModel):
     total_time: float
 
 
+class AISuggestRequest(OptimizeRequest):
+    iterations: int = Field(400, ge=10, le=5000)
+    random_seed: Optional[int] = Field(
+        default=None,
+        description="Optional seed to obtain reproducible suggestions during testing.",
+    )
+
+
+class AISuggestResponse(BaseModel):
+    ordered_stores: List[StoreOutput]
+    total_time: float
+    average_leg_time: float
+    insights: List[str]
+
+
 app = FastAPI(title="Route Optimizer Service")
 
 
@@ -75,6 +91,46 @@ async def optimize_route_endpoint(req: OptimizeRequest) -> OptimizeResponse:
             for s in ordered
         ],
         total_time=total,
+    )
+
+
+@app.post("/ai-suggest-route", response_model=AISuggestResponse)
+async def ai_suggest_route_endpoint(req: AISuggestRequest) -> AISuggestResponse:
+    stores = [
+        Store(
+            identifier=s.identifier,
+            lat=s.lat,
+            lng=s.lng,
+            store_type=s.store_type,
+            service_time=s.service_time,
+            priority=s.priority,
+            traffic_multiplier=s.traffic_multiplier,
+        )
+        for s in req.stores
+    ]
+    ordered, total, insights, avg_leg = ai_suggest_route(
+        (req.start_lat, req.start_lng),
+        stores,
+        req.google_api_key,
+        iterations=req.iterations,
+        random_seed=req.random_seed,
+    )
+    return AISuggestResponse(
+        ordered_stores=[
+            StoreOutput(
+                identifier=s.identifier,
+                lat=s.lat,
+                lng=s.lng,
+                store_type=s.store_type,
+                service_time=s.service_time,
+                priority=s.priority,
+                traffic_multiplier=s.traffic_multiplier,
+            )
+            for s in ordered
+        ],
+        total_time=total,
+        average_leg_time=avg_leg,
+        insights=insights,
     )
 
 

--- a/route_optimizer_service/tests/test_optimizer.py
+++ b/route_optimizer_service/tests/test_optimizer.py
@@ -1,4 +1,5 @@
 from ..optimizer import Store, optimize_route, haversine
+from ..ai import ai_suggest_route
 
 
 def test_haversine_zero_distance():
@@ -13,3 +14,18 @@ def test_optimize_route_orders_by_distance_and_priority():
     ordered, total = optimize_route((0, 0), stores)
     assert [s.identifier for s in ordered] == ["A", "B"]
     assert total > 0
+
+
+def test_ai_suggest_route_returns_insights_and_average_leg():
+    stores = [
+        Store("B", 0, 2, "grocery", service_time=5, priority=2),
+        Store("A", 0, 1, "pharmacy", service_time=5, priority=1),
+        Store("C", 0, 3, "bakery", service_time=4, priority=3),
+    ]
+    suggested, total, insights, average_leg = ai_suggest_route(
+        (0, 0), stores, iterations=40, random_seed=42
+    )
+    assert sorted(store.identifier for store in suggested) == ["A", "B", "C"]
+    assert total > 0
+    assert average_leg >= 0
+    assert insights, "Insights should be generated for AI suggestions"

--- a/shopping-taxi-app/src/app/backend/documents/REQUIREMENTS.txt
+++ b/shopping-taxi-app/src/app/backend/documents/REQUIREMENTS.txt
@@ -186,10 +186,10 @@ Exposes this as a REST API to the main backend.
 
 ## 🧠 Optional Enhancements
 
-* AI suggestion for best shopping route (use Python)
-* Java microservice for trip analytics
-* Referral system
-* Store promotions and deals API
+* [x] AI suggestion for best shopping route (use Python)
+* [x] Java microservice for trip analytics
+* [x] Referral system
+* [x] Store promotions and deals API
 
 ---
 

--- a/shopping-taxi-app/src/app/backend/server_apis_db/config/config.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/config/config.ts
@@ -63,6 +63,8 @@ interface AppConfig {
   db: DBConfig;
   baseUrl: string;
   frontendUrl: string;
+  pythonOptimizerUrl: string;
+  analyticsServiceUrl: string;
 }
 
 const config: AppConfig = {
@@ -76,6 +78,10 @@ const config: AppConfig = {
   },
   baseUrl: process.env.BASE_URL ?? "http://localhost:5000",
   frontendUrl: process.env.FRONTEND_URL || "http://localhost:3000",
+  pythonOptimizerUrl:
+    process.env.PYTHON_OPTIMIZER_URL ?? "http://localhost:8000",
+  analyticsServiceUrl:
+    process.env.ANALYTICS_SERVICE_URL ?? "http://localhost:8085",
 };
 
 export default config;

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/analytics.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/analytics.controller.ts
@@ -1,0 +1,60 @@
+import { RequestHandler } from 'express';
+import {
+  fetchTripSummary,
+  submitTripAnalytics,
+  TripAnalyticsPayload,
+} from '../services/analytics.service';
+
+const validatePayload = (body: any): TripAnalyticsPayload | null => {
+  const {
+    tripId,
+    userId,
+    totalDistanceKm,
+    totalDurationMinutes,
+    stopsVisited,
+    savingsAmount,
+  } = body ?? {};
+
+  if (
+    typeof tripId !== 'number' ||
+    typeof userId !== 'number' ||
+    typeof totalDistanceKm !== 'number' ||
+    typeof totalDurationMinutes !== 'number' ||
+    typeof stopsVisited !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    tripId,
+    userId,
+    totalDistanceKm,
+    totalDurationMinutes,
+    stopsVisited,
+    savingsAmount,
+  };
+};
+
+export const getTripSummary: RequestHandler = async (_req, res, next) => {
+  try {
+    const summary = await fetchTripSummary();
+    res.json(summary);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const ingestTripAnalytics: RequestHandler = async (req, res, next) => {
+  const payload = validatePayload(req.body);
+  if (!payload) {
+    res.status(400).json({ error: 'Invalid analytics payload' });
+    return;
+  }
+
+  try {
+    const result = await submitTripAnalytics(payload);
+    res.status(202).json(result);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/auth.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/auth.controller.ts
@@ -21,14 +21,28 @@ const COOKIE_OPTS = {
 
 // — REGISTER —
 export const register: RequestHandler = async (req, res, next) => {
-  const { username, email, password } = req.body;
+  const { username, email, password, referralCode } = req.body;
   if (!username || !email || !password) {
     res.status(400).json({ error: 'Missing fields' });
     return;
   }
   try {
-    const user = await UserModel.createUser(username, email, password);
-    res.status(201).json({ message: 'Registration successful', user });
+    const user = await UserModel.createUser(username, email, password, 'customer', referralCode);
+    res.status(201).json({
+      message: 'Registration successful',
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        referral: {
+          code: user.referral_code,
+          points: user.referral_points,
+          referredBy: user.referred_by,
+          applied: Boolean(referralCode && user.referred_by),
+        },
+      },
+    });
     return;
   } catch (err: unknown) {
     next(err);

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/promotions.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/promotions.controller.ts
@@ -1,0 +1,144 @@
+import { RequestHandler } from 'express';
+import { AuthenticatedRequest } from '../middleware/jwtMiddleware';
+import * as PromotionsModel from '../models/promotions.model';
+import * as UsersModel from '../models/users.model';
+
+const ensureAdmin = async (userId: number) => {
+  const user = await UsersModel.findUserById(userId);
+  return user?.role === 'admin';
+};
+
+export const listPromotions: RequestHandler = async (req, res, next) => {
+  try {
+    const activeOnly = req.query.active !== 'false';
+    const promotions = await PromotionsModel.getPromotions(activeOnly);
+    res.json({ promotions });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const listPromotionsForStore: RequestHandler = async (req, res, next) => {
+  try {
+    const storeId = Number(req.params.storeId);
+    if (Number.isNaN(storeId)) {
+      res.status(400).json({ error: 'Invalid store id' });
+      return;
+    }
+    const activeOnly = req.query.active !== 'false';
+    const promotions = await PromotionsModel.getPromotionsForStore(storeId, activeOnly);
+    res.json({ promotions });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createPromotion: RequestHandler = async (req, res, next) => {
+  const authReq = req as AuthenticatedRequest;
+  if (!authReq.user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const isAdmin = await ensureAdmin(Number(authReq.user.id));
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Admin privileges required' });
+      return;
+    }
+
+    const { storeId, title, description, discountPercentage, startDate, endDate, isActive } = req.body;
+    const numericStoreId = Number(storeId);
+    const numericDiscount = Number(discountPercentage);
+    if (
+      Number.isNaN(numericStoreId) ||
+      !title ||
+      Number.isNaN(numericDiscount) ||
+      !startDate ||
+      !endDate
+    ) {
+      res.status(400).json({ error: 'Missing or invalid required fields' });
+      return;
+    }
+
+    const promotion = await PromotionsModel.createPromotion({
+      storeId: numericStoreId,
+      title,
+      description,
+      discountPercentage: numericDiscount,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
+      isActive: isActive ?? true,
+    });
+
+    res.status(201).json({ promotion });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updatePromotion: RequestHandler = async (req, res, next) => {
+  const authReq = req as AuthenticatedRequest;
+  if (!authReq.user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const isAdmin = await ensureAdmin(Number(authReq.user.id));
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Admin privileges required' });
+      return;
+    }
+
+    const promotionId = Number(req.params.id);
+    if (Number.isNaN(promotionId)) {
+      res.status(400).json({ error: 'Invalid promotion id' });
+      return;
+    }
+
+    const updates: any = { ...req.body };
+    if (updates.startDate) updates.startDate = new Date(updates.startDate);
+    if (updates.endDate) updates.endDate = new Date(updates.endDate);
+    if (updates.discountPercentage !== undefined) {
+      updates.discountPercentage = Number(updates.discountPercentage);
+    }
+
+    const promotion = await PromotionsModel.updatePromotion(promotionId, updates);
+    if (!promotion) {
+      res.status(404).json({ error: 'Promotion not found' });
+      return;
+    }
+
+    res.json({ promotion });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const archivePromotion: RequestHandler = async (req, res, next) => {
+  const authReq = req as AuthenticatedRequest;
+  if (!authReq.user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const isAdmin = await ensureAdmin(Number(authReq.user.id));
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Admin privileges required' });
+      return;
+    }
+
+    const promotionId = Number(req.params.id);
+    if (Number.isNaN(promotionId)) {
+      res.status(400).json({ error: 'Invalid promotion id' });
+      return;
+    }
+
+    await PromotionsModel.archivePromotion(promotionId);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/referrals.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/referrals.controller.ts
@@ -1,0 +1,42 @@
+import { RequestHandler } from 'express';
+import { AuthenticatedRequest } from '../middleware/jwtMiddleware';
+import * as ReferralsModel from '../models/referrals.model';
+
+export const getReferralProfile: RequestHandler = async (req, res, next) => {
+  const authReq = req as AuthenticatedRequest;
+  if (!authReq.user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const profile = await ReferralsModel.getReferralProfile(Number(authReq.user.id));
+    res.json(profile);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const regenerateReferralCode: RequestHandler = async (req, res, next) => {
+  const authReq = req as AuthenticatedRequest;
+  if (!authReq.user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const code = await ReferralsModel.regenerateReferralCode(Number(authReq.user.id));
+    res.status(201).json({ referralCode: code });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getReferralLeaderboard: RequestHandler = async (_req, res, next) => {
+  try {
+    const leaders = await ReferralsModel.getTopReferrers();
+    res.json({ leaders });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/routeOptimization.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/routeOptimization.controller.ts
@@ -1,0 +1,55 @@
+import { RequestHandler } from 'express';
+import {
+  requestAISuggestion,
+  requestOptimizedRoute,
+  RouteSuggestionPayload,
+} from '../services/routeOptimization.service';
+
+const parsePayload = (body: any): RouteSuggestionPayload => {
+  const { start_lat, start_lng, stores, google_api_key, iterations, random_seed } = body ?? {};
+  if (
+    typeof start_lat !== 'number' ||
+    typeof start_lng !== 'number' ||
+    !Array.isArray(stores) ||
+    !stores.length
+  ) {
+    throw new Error('Invalid payload provided for route suggestion');
+  }
+
+  return {
+    start_lat,
+    start_lng,
+    stores,
+    google_api_key,
+    iterations,
+    random_seed,
+  };
+};
+
+export const getOptimizedRoute: RequestHandler = async (req, res, next) => {
+  try {
+    const payload = parsePayload(req.body);
+    const suggestion = await requestOptimizedRoute(payload);
+    res.json(suggestion);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Invalid payload')) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+};
+
+export const getAISuggestedRoute: RequestHandler = async (req, res, next) => {
+  try {
+    const payload = parsePayload(req.body);
+    const suggestion = await requestAISuggestion(payload);
+    res.json(suggestion);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Invalid payload')) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    next(error);
+  }
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/users.controller.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/users.controller.ts
@@ -14,7 +14,17 @@ export const createUser = async (
 
   try {
     const user = await UserModel.createUser(username, email, password);
-    res.status(201).json(user);
+    res.status(201).json({
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: user.role,
+      referral: {
+        code: user.referral_code,
+        points: user.referral_points,
+        referredBy: user.referred_by,
+      },
+    });
   } catch (err) {
     next(err);
   }

--- a/shopping-taxi-app/src/app/backend/server_apis_db/models/promotions.model.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/models/promotions.model.ts
@@ -1,0 +1,132 @@
+import pool from '../db';
+
+export interface PromotionInput {
+  storeId: number;
+  title: string;
+  description?: string;
+  discountPercentage: number;
+  startDate: Date;
+  endDate: Date;
+  isActive?: boolean;
+}
+
+export interface PromotionRecord {
+  id: number;
+  storeId: number;
+  title: string;
+  description: string | null;
+  discountPercentage: number;
+  startDate: Date;
+  endDate: Date;
+  isActive: boolean;
+  createdAt: Date;
+}
+
+const mapPromotion = (row: any): PromotionRecord => ({
+  id: row.id,
+  storeId: row.store_id,
+  title: row.title,
+  description: row.description,
+  discountPercentage: Number(row.discount_percentage),
+  startDate: row.start_date,
+  endDate: row.end_date,
+  isActive: row.is_active,
+  createdAt: row.created_at,
+});
+
+export const createPromotion = async (
+  input: PromotionInput,
+): Promise<PromotionRecord> => {
+  const result = await pool.query(
+    `INSERT INTO promotions (store_id, title, description, discount_percentage, start_date, end_date, is_active)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+  RETURNING id, store_id, title, description, discount_percentage, start_date, end_date, is_active, created_at`,
+    [
+      input.storeId,
+      input.title,
+      input.description ?? null,
+      input.discountPercentage,
+      input.startDate,
+      input.endDate,
+      input.isActive ?? true,
+    ],
+  );
+
+  return mapPromotion(result.rows[0]);
+};
+
+export const getPromotions = async (onlyActive = false) => {
+  const result = await pool.query(
+    `SELECT id, store_id, title, description, discount_percentage, start_date, end_date, is_active, created_at
+       FROM promotions
+      ${onlyActive ? 'WHERE is_active = true AND end_date >= NOW()' : ''}
+   ORDER BY start_date ASC`,
+  );
+  return result.rows.map(mapPromotion);
+};
+
+export const getPromotionsForStore = async (
+  storeId: number,
+  onlyActive = true,
+) => {
+  const result = await pool.query(
+    `SELECT id, store_id, title, description, discount_percentage, start_date, end_date, is_active, created_at
+       FROM promotions
+      WHERE store_id = $1
+        ${onlyActive ? 'AND is_active = true AND end_date >= NOW()' : ''}
+   ORDER BY start_date ASC`,
+    [storeId],
+  );
+  return result.rows.map(mapPromotion);
+};
+
+export const updatePromotion = async (
+  promotionId: number,
+  updates: Partial<PromotionInput>,
+) => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let index = 1;
+
+  if (updates.title !== undefined) {
+    fields.push(`title = $${index++}`);
+    values.push(updates.title);
+  }
+  if (updates.description !== undefined) {
+    fields.push(`description = $${index++}`);
+    values.push(updates.description);
+  }
+  if (updates.discountPercentage !== undefined) {
+    fields.push(`discount_percentage = $${index++}`);
+    values.push(updates.discountPercentage);
+  }
+  if (updates.startDate !== undefined) {
+    fields.push(`start_date = $${index++}`);
+    values.push(updates.startDate);
+  }
+  if (updates.endDate !== undefined) {
+    fields.push(`end_date = $${index++}`);
+    values.push(updates.endDate);
+  }
+  if (updates.isActive !== undefined) {
+    fields.push(`is_active = $${index++}`);
+    values.push(updates.isActive);
+  }
+
+  if (!fields.length) {
+    const existing = await pool.query(
+      'SELECT id, store_id, title, description, discount_percentage, start_date, end_date, is_active, created_at FROM promotions WHERE id = $1',
+      [promotionId],
+    );
+    return existing.rowCount ? mapPromotion(existing.rows[0]) : null;
+  }
+
+  values.push(promotionId);
+  const query = `UPDATE promotions SET ${fields.join(', ')} WHERE id = $${index} RETURNING id, store_id, title, description, discount_percentage, start_date, end_date, is_active, created_at`;
+  const result = await pool.query(query, values);
+  return result.rowCount ? mapPromotion(result.rows[0]) : null;
+};
+
+export const archivePromotion = async (promotionId: number) => {
+  await pool.query('UPDATE promotions SET is_active = false WHERE id = $1', [promotionId]);
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/models/referrals.model.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/models/referrals.model.ts
@@ -1,0 +1,88 @@
+import { PoolClient } from 'pg';
+import pool from '../db';
+import { generateUniqueReferralCode } from './users.model';
+
+export interface ReferralProfile {
+  referralCode: string;
+  referralPoints: number;
+  totalReferred: number;
+  referrals: Array<{
+    id: number;
+    refereeName: string;
+    refereeEmail: string;
+    rewardPoints: number;
+    status: string;
+    createdAt: Date;
+  }>;
+}
+
+export const getReferralProfile = async (
+  userId: number,
+): Promise<ReferralProfile> => {
+  const userResult = await pool.query(
+    'SELECT referral_code, referral_points FROM users WHERE id = $1',
+    [userId],
+  );
+
+  if (!userResult.rowCount) {
+    throw new Error('User not found');
+  }
+
+  const referralsResult = await pool.query(
+    `SELECT r.id,
+            r.reward_points,
+            r.status,
+            r.created_at,
+            u.username AS referee_name,
+            u.email AS referee_email
+       FROM referrals r
+  LEFT JOIN users u ON u.id = r.referee_id
+      WHERE r.referrer_id = $1
+   ORDER BY r.created_at DESC`,
+    [userId],
+  );
+
+  return {
+    referralCode: userResult.rows[0].referral_code,
+    referralPoints: userResult.rows[0].referral_points,
+    totalReferred: referralsResult.rowCount,
+    referrals: referralsResult.rows.map((row) => ({
+      id: row.id,
+      refereeName: row.referee_name,
+      refereeEmail: row.referee_email,
+      rewardPoints: row.reward_points,
+      status: row.status,
+      createdAt: row.created_at,
+    })),
+  };
+};
+
+export const regenerateReferralCode = async (
+  userId: number,
+): Promise<string> => {
+  const client: PoolClient = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const newCode = await generateUniqueReferralCode(client);
+    await client.query('UPDATE users SET referral_code = $1 WHERE id = $2', [newCode, userId]);
+    await client.query('COMMIT');
+    return newCode;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const getTopReferrers = async (limit = 5) => {
+  const result = await pool.query(
+    `SELECT id, username, referral_points
+       FROM users
+   ORDER BY referral_points DESC
+      LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows;
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/models/users.model.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/models/users.model.ts
@@ -1,29 +1,103 @@
 // src/models/users.model.ts
 import pool from '../db';
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
+import { PoolClient } from 'pg';
+
+const REFERRAL_REWARD_POINTS = 100;
+const REFEREE_BONUS_POINTS = 25;
 
 const SALT_ROUNDS = 10;
+
+const generateReferralCandidate = () =>
+  crypto.randomBytes(4).toString('hex').toUpperCase();
+
+export const generateUniqueReferralCode = async (
+  client: PoolClient,
+): Promise<string> => {
+  let code = generateReferralCandidate();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const existing = await client.query(
+      'SELECT 1 FROM users WHERE referral_code = $1',
+      [code],
+    );
+    if (!existing.rowCount) {
+      return code;
+    }
+    code = generateReferralCandidate();
+  }
+};
 
 export const createUser = async (
   username: string,
   email: string,
   password: string,
-  role: string = 'customer'
+  role: string = 'customer',
+  referralCode?: string,
 ) => {
-  // 1. Hash & salt the password
-  const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
 
-  const result = await pool.query(
-    'INSERT INTO users (username, email, password, role) VALUES ($1, $2, $3, $4) RETURNING id, username, email, role, created_at',
-    [username, email, hashedPassword, role]
-  );
+    const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
+    let referredBy: number | null = null;
 
-  // We return only the safe fields (no password)
-  return result.rows[0];
+    if (referralCode) {
+      const referrer = await client.query(
+        'SELECT id FROM users WHERE referral_code = $1',
+        [referralCode],
+      );
+      if (referrer.rowCount) {
+        referredBy = referrer.rows[0].id;
+      }
+    }
+
+    const generatedCode = await generateUniqueReferralCode(client);
+    const insertResult = await client.query(
+      'INSERT INTO users (username, email, password, role, referral_code, referred_by) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, username, email, role, referral_code, referral_points, referred_by, created_at',
+      [username, email, hashedPassword, role, generatedCode, referredBy],
+    );
+
+    const user = insertResult.rows[0];
+
+    if (referredBy) {
+      await client.query(
+        'INSERT INTO referrals (referrer_id, referee_id, referral_code, reward_points, status) VALUES ($1, $2, $3, $4, $5)',
+        [referredBy, user.id, referralCode, REFERRAL_REWARD_POINTS, 'completed'],
+      );
+
+      await client.query(
+        'UPDATE users SET referral_points = referral_points + $1 WHERE id = $2',
+        [REFERRAL_REWARD_POINTS, referredBy],
+      );
+
+      await client.query(
+        'UPDATE users SET referral_points = referral_points + $1 WHERE id = $2',
+        [REFEREE_BONUS_POINTS, user.id],
+      );
+    }
+
+    await client.query('COMMIT');
+    return user;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 };
 
 export const findUserByEmail = async (email: string) => {
   const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+  return result.rows[0];
+};
+
+export const findUserByReferralCode = async (code: string) => {
+  const result = await pool.query(
+    'SELECT id, username, email, role, referral_code, referral_points FROM users WHERE referral_code = $1',
+    [code],
+  );
   return result.rows[0];
 };
 

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/analytics.routes.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/analytics.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import {
+  getTripSummary,
+  ingestTripAnalytics,
+} from '../controllers/analytics.controller';
+
+const router = Router();
+
+router.get('/summary', getTripSummary);
+router.post('/ingest', ingestTripAnalytics);
+
+export default router;

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/promotions.routes.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/promotions.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listPromotions,
+  listPromotionsForStore,
+  createPromotion,
+  updatePromotion,
+  archivePromotion,
+} from '../controllers/promotions.controller';
+
+const router = Router();
+
+router.get('/', listPromotions);
+router.get('/store/:storeId', listPromotionsForStore);
+router.post('/', createPromotion);
+router.patch('/:id', updatePromotion);
+router.delete('/:id', archivePromotion);
+
+export default router;

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/referrals.routes.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/referrals.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  getReferralProfile,
+  regenerateReferralCode,
+  getReferralLeaderboard,
+} from '../controllers/referrals.controller';
+
+const router = Router();
+
+router.get('/profile', getReferralProfile);
+router.post('/regenerate', regenerateReferralCode);
+router.get('/leaderboard', getReferralLeaderboard);
+
+export default router;

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/routeOptimization.routes.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/routeOptimization.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import {
+  getAISuggestedRoute,
+  getOptimizedRoute,
+} from '../controllers/routeOptimization.controller';
+
+const router = Router();
+
+router.post('/optimize', getOptimizedRoute);
+router.post('/ai-suggestion', getAISuggestedRoute);
+
+export default router;

--- a/shopping-taxi-app/src/app/backend/server_apis_db/server.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/server.ts
@@ -17,6 +17,10 @@ import storeItemRoutes from './routes/storeItems.routes';
 import tripRoutes from './routes/trips.routes';
 import tripItemRoutes from './routes/tripItems.routes';
 import ratingRoutes from './routes/ratings.routes';
+import referralRoutes from './routes/referrals.routes';
+import promotionsRoutes from './routes/promotions.routes';
+import routeOptimizationRoutes from './routes/routeOptimization.routes';
+import analyticsRoutes from './routes/analytics.routes';
 
 // If using Socket.IO types, ensure you have installed @types/socket.io
 // npm install socket.io @types/socket.io
@@ -63,6 +67,10 @@ app.use('/api/store-items', storeItemRoutes);
 app.use('/api/trips', tripRoutes);
 app.use('/api/trip-items', tripItemRoutes);
 app.use('/api/ratings', ratingRoutes);
+app.use('/api/referrals', referralRoutes);
+app.use('/api/promotions', promotionsRoutes);
+app.use('/api/route-optimization', routeOptimizationRoutes);
+app.use('/api/analytics', analyticsRoutes);
 
 // Error handlers
 app.use(notFound);

--- a/shopping-taxi-app/src/app/backend/server_apis_db/services/analytics.service.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/services/analytics.service.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import config from '../config/config';
+
+const client = axios.create({
+  baseURL: config.analyticsServiceUrl,
+  timeout: 8000,
+});
+
+export interface TripAnalyticsPayload {
+  tripId: number;
+  userId: number;
+  totalDistanceKm: number;
+  totalDurationMinutes: number;
+  stopsVisited: number;
+  savingsAmount?: number;
+}
+
+export const fetchTripSummary = async () => {
+  const response = await client.get('/analytics/summary');
+  return response.data;
+};
+
+export const submitTripAnalytics = async (payload: TripAnalyticsPayload) => {
+  const response = await client.post('/analytics/ingest', payload);
+  return response.data;
+};

--- a/shopping-taxi-app/src/app/backend/server_apis_db/services/routeOptimization.service.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/services/routeOptimization.service.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import config from '../config/config';
+
+const client = axios.create({
+  baseURL: config.pythonOptimizerUrl,
+  timeout: 10000,
+});
+
+export interface StoreStopPayload {
+  identifier: string;
+  lat: number;
+  lng: number;
+  store_type: string;
+  service_time: number;
+  priority: number;
+  traffic_multiplier?: number;
+}
+
+export interface RouteSuggestionPayload {
+  start_lat: number;
+  start_lng: number;
+  stores: StoreStopPayload[];
+  google_api_key?: string;
+  iterations?: number;
+  random_seed?: number;
+}
+
+export const requestOptimizedRoute = async (payload: RouteSuggestionPayload) => {
+  const response = await client.post('/optimize-route', payload);
+  return response.data;
+};
+
+export const requestAISuggestion = async (payload: RouteSuggestionPayload) => {
+  const response = await client.post('/ai-suggest-route', payload);
+  return response.data;
+};

--- a/trip-analytics-service/README.md
+++ b/trip-analytics-service/README.md
@@ -1,0 +1,35 @@
+# Trip Analytics Service
+
+A Spring Boot microservice that provides aggregated analytics for Shopta trips.
+It stores recent trip metrics in-memory and exposes endpoints for summaries and
+new analytics submissions.
+
+## Running locally
+
+```bash
+mvn spring-boot:run
+```
+
+By default the service listens on `http://localhost:8085`.
+
+## API
+
+- `GET /analytics/summary` – Returns average distance, duration, stop counts and
+  a feed of the most recent trips submitted to the service.
+- `POST /analytics/ingest` – Accepts a JSON payload with trip distance, duration
+  and optional savings. The request updates the rolling analytics snapshot and
+  returns the refreshed summary. Example:
+
+```json
+{
+  "tripId": 42,
+  "userId": 7,
+  "totalDistanceKm": 18.4,
+  "totalDurationMinutes": 52,
+  "stopsVisited": 4,
+  "savingsAmount": 6.5
+}
+```
+
+The service keeps recent events in memory, making it easy to deploy alongside
+other Shopta services without additional infrastructure.

--- a/trip-analytics-service/pom.xml
+++ b/trip-analytics-service/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.shopta</groupId>
+    <artifactId>trip-analytics-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>trip-analytics-service</name>
+    <description>Trip analytics microservice for Shopta</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/TripAnalyticsServiceApplication.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/TripAnalyticsServiceApplication.java
@@ -1,0 +1,12 @@
+package com.shopta.analytics;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TripAnalyticsServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TripAnalyticsServiceApplication.class, args);
+    }
+}

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/controller/AnalyticsController.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/controller/AnalyticsController.java
@@ -1,0 +1,31 @@
+package com.shopta.analytics.controller;
+
+import com.shopta.analytics.model.TripAnalyticsRequest;
+import com.shopta.analytics.model.TripSummary;
+import com.shopta.analytics.service.TripAnalyticsService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/analytics")
+@CrossOrigin
+public class AnalyticsController {
+
+    private final TripAnalyticsService analyticsService;
+
+    public AnalyticsController(TripAnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @GetMapping("/summary")
+    public TripSummary getSummary() {
+        return analyticsService.getSummary();
+    }
+
+    @PostMapping("/ingest")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public TripSummary ingest(@Valid @RequestBody TripAnalyticsRequest request) {
+        return analyticsService.ingest(request);
+    }
+}

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripAnalyticsRequest.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripAnalyticsRequest.java
@@ -1,0 +1,14 @@
+package com.shopta.analytics.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record TripAnalyticsRequest(
+        @NotNull @Min(1) Long tripId,
+        @NotNull @Min(1) Long userId,
+        @NotNull @Min(0) Double totalDistanceKm,
+        @NotNull @Min(0) Double totalDurationMinutes,
+        @NotNull @Min(0) Integer stopsVisited,
+        Double savingsAmount
+) {
+}

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripSummary.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripSummary.java
@@ -1,0 +1,13 @@
+package com.shopta.analytics.model;
+
+import java.util.List;
+
+public record TripSummary(
+        int totalTrips,
+        double averageDistanceKm,
+        double averageDurationMinutes,
+        double averageStops,
+        double averageSavings,
+        List<TripSummarySnapshot> recentTrips
+) {
+}

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripSummarySnapshot.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/model/TripSummarySnapshot.java
@@ -1,0 +1,14 @@
+package com.shopta.analytics.model;
+
+import java.time.Instant;
+
+public record TripSummarySnapshot(
+        long tripId,
+        long userId,
+        double totalDistanceKm,
+        double totalDurationMinutes,
+        int stopsVisited,
+        double savingsAmount,
+        Instant recordedAt
+) {
+}

--- a/trip-analytics-service/src/main/java/com/shopta/analytics/service/TripAnalyticsService.java
+++ b/trip-analytics-service/src/main/java/com/shopta/analytics/service/TripAnalyticsService.java
@@ -1,0 +1,66 @@
+package com.shopta.analytics.service;
+
+import com.shopta.analytics.model.TripAnalyticsRequest;
+import com.shopta.analytics.model.TripSummary;
+import com.shopta.analytics.model.TripSummarySnapshot;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+public class TripAnalyticsService {
+
+    private final CopyOnWriteArrayList<TripSummarySnapshot> events = new CopyOnWriteArrayList<>();
+
+    public TripSummary getSummary() {
+        int totalTrips = events.size();
+        double averageDistance = totalTrips == 0 ? 0.0 : events.stream()
+                .mapToDouble(TripSummarySnapshot::totalDistanceKm)
+                .average()
+                .orElse(0.0);
+
+        double averageDuration = totalTrips == 0 ? 0.0 : events.stream()
+                .mapToDouble(TripSummarySnapshot::totalDurationMinutes)
+                .average()
+                .orElse(0.0);
+
+        double averageStops = totalTrips == 0 ? 0.0 : events.stream()
+                .mapToDouble(TripSummarySnapshot::stopsVisited)
+                .average()
+                .orElse(0.0);
+
+        double averageSavings = totalTrips == 0 ? 0.0 : events.stream()
+                .mapToDouble(TripSummarySnapshot::savingsAmount)
+                .average()
+                .orElse(0.0);
+
+        List<TripSummarySnapshot> recentTrips = events.stream()
+                .sorted(Comparator.comparing(TripSummarySnapshot::recordedAt).reversed())
+                .limit(10)
+                .toList();
+
+        return new TripSummary(totalTrips, averageDistance, averageDuration, averageStops, averageSavings, recentTrips);
+    }
+
+    public TripSummary ingest(TripAnalyticsRequest request) {
+        double savings = request.savingsAmount() == null ? 0.0 : request.savingsAmount();
+        TripSummarySnapshot snapshot = new TripSummarySnapshot(
+                request.tripId(),
+                request.userId(),
+                request.totalDistanceKm(),
+                request.totalDurationMinutes(),
+                request.stopsVisited(),
+                savings,
+                Instant.now()
+        );
+        events.add(snapshot);
+        return getSummary();
+    }
+
+    public void clear() {
+        events.clear();
+    }
+}

--- a/trip-analytics-service/src/main/resources/application.properties
+++ b/trip-analytics-service/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8085
+spring.application.name=trip-analytics-service

--- a/trip-analytics-service/src/test/java/com/shopta/analytics/TripAnalyticsServiceTest.java
+++ b/trip-analytics-service/src/test/java/com/shopta/analytics/TripAnalyticsServiceTest.java
@@ -1,0 +1,37 @@
+package com.shopta.analytics;
+
+import com.shopta.analytics.model.TripAnalyticsRequest;
+import com.shopta.analytics.model.TripSummary;
+import com.shopta.analytics.service.TripAnalyticsService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TripAnalyticsServiceTest {
+
+    private final TripAnalyticsService service = new TripAnalyticsService();
+
+    @AfterEach
+    void tearDown() {
+        service.clear();
+    }
+
+    @Test
+    void summaryStartsEmpty() {
+        TripSummary summary = service.getSummary();
+        assertThat(summary.totalTrips()).isZero();
+        assertThat(summary.averageDistanceKm()).isZero();
+    }
+
+    @Test
+    void ingestUpdatesSummary() {
+        TripAnalyticsRequest request = new TripAnalyticsRequest(1L, 2L, 12.5, 30.0, 3, 4.0);
+        TripSummary summary = service.ingest(request);
+
+        assertThat(summary.totalTrips()).isEqualTo(1);
+        assertThat(summary.averageDistanceKm()).isEqualTo(12.5);
+        assertThat(summary.recentTrips()).hasSize(1);
+        assertThat(summary.recentTrips().get(0).tripId()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Python route optimizer with a heuristic AI suggestion module, FastAPI endpoint and tests that return narrative insights alongside travel metrics
- expand the Node backend with referral tracking, store promotions management, and proxy routes to the Python optimizer and a new analytics service
- scaffold a Spring Boot trip-analytics microservice with REST endpoints, documentation, and unit coverage

## Testing
- python -m pytest route_optimizer_service/tests
- npm test
- npm run lint
- mvn -q test *(fails: unable to resolve Spring Boot parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8558d6c7483308bbf793e137143d5