### PR TITLE
Persist trip planner stops and add trip detail page

### DIFF
--- a/shopping-taxi-app/src/app/Frontend/Customer/TripPlanner/__tests__/TripPlanner.test.ts
+++ b/shopping-taxi-app/src/app/Frontend/Customer/TripPlanner/__tests__/TripPlanner.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import test, { mock } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -9,4 +9,40 @@ const content = fs.readFileSync(filePath, 'utf8');
 test('TripPlanner page contains expected headings', () => {
   assert.ok(content.includes('Select Stops'));
   assert.ok(content.includes('Vehicle Size'));
+});
+
+test('submitTrip posts stops with real store ids', async () => {
+  const TripPlannerModule = await import('../tripPlannerUtils.ts');
+  const apiClient = (await import('../../../../services/apiClient.ts')).default;
+  const postMock = mock.method(apiClient, 'post', async (url, payload, config) => {
+    assert.strictEqual(url, '/trips');
+    assert.deepStrictEqual(payload, {
+      stops: [{ store_id: 42, sequence: 1 }],
+      vehicleSize: 'standard',
+    });
+    assert.strictEqual(config?.withCredentials, true);
+    return { data: { tripId: 77 } } as const;
+  });
+
+  const stops: TripPlannerModule.Stop[] = [
+    {
+      id: 'place-1',
+      description: '123 Main St, City',
+      location: { lat: 10, lng: 20 },
+      storeId: 42,
+      storeName: 'Test Store',
+      storeAddress: '123 Main St, City',
+    },
+  ];
+  const pushed: string[] = [];
+  const result = await TripPlannerModule.submitTrip(stops, 'standard', {
+    push: (href: string) => {
+      pushed.push(href);
+    },
+  });
+
+  assert.deepStrictEqual(result, { tripId: 77 });
+  assert.deepStrictEqual(pushed, ['/Frontend/Customer/Trips/77']);
+  assert.strictEqual(postMock.mock.calls.length, 1);
+  postMock.mock.restore();
 });

--- a/shopping-taxi-app/src/app/Frontend/Customer/TripPlanner/tripPlannerUtils.ts
+++ b/shopping-taxi-app/src/app/Frontend/Customer/TripPlanner/tripPlannerUtils.ts
@@ -1,0 +1,68 @@
+import apiClient from '../../../services/apiClient';
+
+export type Place = {
+  id: string;
+  description: string;
+  location: { lat: number; lng: number };
+};
+
+export type Stop = Place & {
+  storeId: number;
+  storeName: string;
+  storeAddress: string;
+};
+
+export const persistPlaceAsStore = async (place: Place): Promise<Stop> => {
+  const fallbackName = place.description.split(',')[0]?.trim() || place.description;
+  const response = await apiClient.post(
+    '/stores',
+    {
+      name: fallbackName,
+      address: place.description,
+      latitude: place.location.lat,
+      longitude: place.location.lng,
+    },
+    { withCredentials: true }
+  );
+  const store = response.data;
+  if (!store || typeof store.id !== 'number') {
+    throw new Error('Invalid store response');
+  }
+  return {
+    ...place,
+    storeId: store.id,
+    storeName: store.name ?? fallbackName,
+    storeAddress: store.address ?? place.description,
+  };
+};
+
+export const buildTripPayload = (
+  stops: Stop[],
+  vehicleSize: 'small' | 'standard' | 'large'
+) => ({
+  stops: stops.map((stop, index) => ({ store_id: stop.storeId, sequence: index + 1 })),
+  vehicleSize,
+});
+
+export const submitTrip = async (
+  stops: Stop[],
+  vehicleSize: 'small' | 'standard' | 'large',
+  router: { push: (url: string) => void }
+) => {
+  if (!stops.length) {
+    throw new Error('Add at least one stop before starting a trip.');
+  }
+  const invalidStop = stops.find((stop) => typeof stop.storeId !== 'number' || !Number.isFinite(stop.storeId));
+  if (invalidStop) {
+    throw new Error('Stops must reference saved stores.');
+  }
+
+  const payload = buildTripPayload(stops, vehicleSize);
+  const res = await apiClient.post('/trips', payload, { withCredentials: true });
+  const tripId = res.data?.tripId;
+  if (typeof tripId !== 'number') {
+    throw new Error('Trip creation response did not include a trip id.');
+  }
+  router.push(`/Frontend/Customer/Trips/${tripId}`);
+  return res.data;
+};

--- a/shopping-taxi-app/src/app/Frontend/Customer/Trips/[id]/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Customer/Trips/[id]/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import apiClient from '../../../../services/apiClient';
+
+interface TripStop {
+  id: number;
+  store_id: number;
+  sequence: number;
+  visited: boolean;
+}
+
+interface TripDetail {
+  id: number;
+  vehicle_size?: string;
+  created_at?: string;
+  stops?: TripStop[];
+}
+
+interface StoreSummary {
+  name: string;
+  address: string;
+}
+
+export default function TripDetailPage({ params }: { params: { id: string } }) {
+  const tripId = Number(params.id);
+  const [trip, setTrip] = useState<TripDetail | null>(null);
+  const [stores, setStores] = useState<Record<number, StoreSummary>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const sortedStops = useMemo(() => {
+    return (trip?.stops ?? []).slice().sort((a, b) => a.sequence - b.sequence);
+  }, [trip?.stops]);
+
+  useEffect(() => {
+    let active = true;
+    const loadTrip = async () => {
+      if (!Number.isFinite(tripId)) {
+        setError('Invalid trip id.');
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const [tripRes, storeRes] = await Promise.all([
+          apiClient.get('/trips/driver', { withCredentials: true }),
+          apiClient.get('/stores', { withCredentials: true }),
+        ]);
+        if (!active) return;
+        const trips: TripDetail[] = tripRes.data?.trips ?? [];
+        const found = trips.find((t) => t.id === tripId) ?? null;
+        if (!found) {
+          setTrip(null);
+          setError('Trip not found.');
+          return;
+        }
+        const storeIndex: Record<number, StoreSummary> = {};
+        const storeList = storeRes.data?.stores ?? [];
+        for (const store of storeList) {
+          if (store && typeof store.id === 'number') {
+            storeIndex[store.id] = {
+              name: store.name ?? `Store ${store.id}`,
+              address: store.address ?? '',
+            };
+          }
+        }
+        setStores(storeIndex);
+        setTrip(found);
+      } catch (err) {
+        console.error('Failed to load trip details', err);
+        if (active) {
+          setTrip(null);
+          setError('Failed to load trip details.');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    loadTrip();
+    return () => {
+      active = false;
+    };
+  }, [tripId]);
+
+  return (
+    <main className="p-8 space-y-4">
+      <h1>Trip #{Number.isFinite(tripId) ? tripId : 'Unknown'}</h1>
+      {loading && <p>Loading trip details…</p>}
+      {error && !loading && <p className="text-red-600">{error}</p>}
+      {!loading && !error && trip && (
+        <>
+          {trip.vehicle_size && <p>Vehicle size: {trip.vehicle_size}</p>}
+          <section className="space-y-2">
+            <h2>Stops</h2>
+            {sortedStops.length ? (
+              <ol className="list-decimal list-inside space-y-3">
+                {sortedStops.map((stop) => {
+                  const store = stores[stop.store_id];
+                  return (
+                    <li key={stop.id}>
+                      <div className="font-semibold">{store?.name ?? `Store ${stop.store_id}`}</div>
+                      {store?.address && <div className="text-sm text-gray-600">{store.address}</div>}
+                      <div className="text-sm">Status: {stop.visited ? 'Visited' : 'Pending'}</div>
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <p>No stops recorded for this trip yet.</p>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/shopping-taxi-app/src/app/components2/PlacesAutocomplete.tsx
+++ b/shopping-taxi-app/src/app/components2/PlacesAutocomplete.tsx
@@ -4,7 +4,9 @@ import usePlacesAutocomplete, { getGeocode, getLatLng } from 'use-places-autocom
 import { Combobox, ComboboxInput, ComboboxPopover, ComboboxList, ComboboxOption } from '@reach/combobox';
 import '@reach/combobox/styles.css';
 
-interface Props { onSelect: (place: { id: string; description: string; location: { lat: number; lng: number } }) => void; }
+interface Props {
+  onSelect: (place: { id: string; description: string; location: { lat: number; lng: number } }) => void | Promise<void>;
+}
 export const PlacesAutocomplete: FC<Props> = ({ onSelect }) => {
   const { ready, value, suggestions, setValue, clearSuggestions } = usePlacesAutocomplete({ requestOptions: { /* bounds, etc */ } });
   const handleSelect = async (address: string) => {
@@ -12,7 +14,7 @@ export const PlacesAutocomplete: FC<Props> = ({ onSelect }) => {
     clearSuggestions();
     const results = await getGeocode({ address });
     const { lat, lng } = await getLatLng(results[0]);
-    onSelect({ id: results[0].place_id, description: address, location: { lat, lng } });
+    await onSelect({ id: results[0].place_id, description: address, location: { lat, lng } });
   };
   return (
     <Combobox onSelect={handleSelect} aria-label="Store location">

--- a/shopping-taxi-app/src/app/services/apiClient.ts
+++ b/shopping-taxi-app/src/app/services/apiClient.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { isTokenExpired } from '@/app/utils/jwt';
+import { isTokenExpired } from '../utils/jwt';
 import { getAccessToken, setAccessToken } from './tokenService';
 
 const baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5001/api';


### PR DESCRIPTION
## Summary
- persist trip planner stops by creating stores, capturing their ids, and submitting trips with real store references
- add shared trip planner utilities and a customer trip detail page that loads stops and store metadata
- update the trip planner regression test and autocomplete component to support the new persistence flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc268030ec8330b7b3c79679c8a01b