### PR TITLE
Add trip retrieval endpoints with tests

### DIFF
--- a/shopping-taxi-app/src/app/backend/server_apis_db/controllers/__tests__/trips.controller.test.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/controllers/__tests__/trips.controller.test.ts
@@ -1,0 +1,157 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert';
+
+process.env.DB_USER = 'test';
+process.env.DB_HOST = 'localhost';
+process.env.DB_NAME = 'testdb';
+process.env.DB_PASSWORD = 'secret';
+process.env.ACCESS_TOKEN_SECRET = 'access';
+process.env.REFRESH_TOKEN_SECRET = 'refresh';
+
+const pool = (await import('../../db.ts')).default;
+const { getTripById, getTripStop } = await import('../trips.controller.ts');
+
+const createMockRes = () => {
+  const res: any = {};
+  res.status = mock.fn((code: number) => { res.statusCode = code; return res; });
+  res.json = mock.fn((body: unknown) => { res.body = body; });
+  return res;
+};
+
+test('getTripById returns trip with formatted stops', async () => {
+  mock.restoreAll();
+  const req: any = { params: { id: '42' } };
+  const res = createMockRes();
+  const tripRow = {
+    id: 42,
+    user_id: 7,
+    created_at: '2024-01-01T00:00:00.000Z',
+    vehicle_size: 'standard',
+  };
+  const stopRow = {
+    id: 1,
+    trip_id: 42,
+    store_id: 9,
+    visited: false,
+    sequence: 1,
+    store_name: 'Fresh Mart',
+    store_address: '123 Main',
+    latitude: 1.23,
+    longitude: 4.56,
+  };
+  mock.method(pool, 'query', async (text: string) => {
+    if (text.startsWith('SELECT * FROM trips WHERE id = $1')) {
+      return { rows: [tripRow] };
+    }
+    if (text.includes('FROM trip_stops') && text.includes('trip_id')) {
+      return { rows: [stopRow] };
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  });
+  await getTripById(req, res, () => {});
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], {
+    id: 42,
+    user_id: 7,
+    vehicle_size: 'standard',
+    created_at: '2024-01-01T00:00:00.000Z',
+    stops: [
+      {
+        id: 1,
+        trip_id: 42,
+        store_id: 9,
+        visited: false,
+        sequence: 1,
+        name: 'Fresh Mart',
+        address: '123 Main',
+        latitude: 1.23,
+        longitude: 4.56,
+      },
+    ],
+  });
+});
+
+test('getTripById responds with 404 when trip is missing', async () => {
+  mock.restoreAll();
+  const req: any = { params: { id: '55' } };
+  const res = createMockRes();
+  mock.method(pool, 'query', async (text: string) => {
+    if (text.startsWith('SELECT * FROM trips WHERE id = $1')) {
+      return { rows: [] };
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  });
+  await getTripById(req, res, () => {});
+  assert.strictEqual(res.status.mock.calls[0].arguments[0], 404);
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { error: 'Trip not found' });
+});
+
+test('getTripById validates the identifier', async () => {
+  mock.restoreAll();
+  const req: any = { params: { id: 'abc' } };
+  const res = createMockRes();
+  mock.method(pool, 'query', async () => { throw new Error('should not be called'); });
+  await getTripById(req, res, () => {});
+  assert.strictEqual(res.status.mock.calls[0].arguments[0], 400);
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { error: 'Invalid trip id' });
+});
+
+test('getTripStop returns stop with coordinates and metadata', async () => {
+  mock.restoreAll();
+  const req: any = { params: { stopId: '9' } };
+  const res = createMockRes();
+  const stop = {
+    id: 9,
+    trip_id: 3,
+    store_id: 11,
+    visited: true,
+    sequence: 2,
+    store_name: 'Corner Shop',
+    store_address: '456 Side St',
+    latitude: 7.89,
+    longitude: -1.23,
+  };
+  mock.method(pool, 'query', async (text: string) => {
+    if (text.includes('WHERE ts.id = $1')) {
+      return { rows: [stop] };
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  });
+  await getTripStop(req, res, () => {});
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], {
+    id: 9,
+    trip_id: 3,
+    store_id: 11,
+    visited: true,
+    sequence: 2,
+    name: 'Corner Shop',
+    address: '456 Side St',
+    coords: [7.89, -1.23],
+    latitude: 7.89,
+    longitude: -1.23,
+  });
+});
+
+test('getTripStop responds with 404 when stop not found', async () => {
+  mock.restoreAll();
+  const req: any = { params: { stopId: '9' } };
+  const res = createMockRes();
+  mock.method(pool, 'query', async (text: string) => {
+    if (text.includes('WHERE ts.id = $1')) {
+      return { rows: [] };
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  });
+  await getTripStop(req, res, () => {});
+  assert.strictEqual(res.status.mock.calls[0].arguments[0], 404);
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { error: 'Trip stop not found' });
+});
+
+test('getTripStop validates the stop identifier', async () => {
+  mock.restoreAll();
+  const req: any = { params: { stopId: 'oops' } };
+  const res = createMockRes();
+  mock.method(pool, 'query', async () => { throw new Error('should not be called'); });
+  await getTripStop(req, res, () => {});
+  assert.strictEqual(res.status.mock.calls[0].arguments[0], 400);
+  assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { error: 'Invalid stop id' });
+});

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/__tests__/trips.routes.test.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/__tests__/trips.routes.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+process.env.DB_USER = 'test';
+process.env.DB_HOST = 'localhost';
+process.env.DB_NAME = 'testdb';
+process.env.DB_PASSWORD = 'secret';
+process.env.ACCESS_TOKEN_SECRET = 'access';
+process.env.REFRESH_TOKEN_SECRET = 'refresh';
+
+const tripsRouter = (await import('../trips.routes')).default;
+
+test('trips router defines GET /stops/:stopId', () => {
+  const layer = tripsRouter.stack.find((l: any) => l.route?.path === '/stops/:stopId');
+  assert.ok(layer?.route.methods.get);
+});
+
+test('trips router defines GET /:id', () => {
+  const layer = tripsRouter.stack.find((l: any) => l.route?.path === '/:id');
+  assert.ok(layer?.route.methods.get);
+});

--- a/shopping-taxi-app/src/app/backend/server_apis_db/routes/trips.routes.ts
+++ b/shopping-taxi-app/src/app/backend/server_apis_db/routes/trips.routes.ts
@@ -23,17 +23,26 @@ router.get(
     jwtMiddleware,
     TripCtrl.getDriverTrips as RequestHandler
 );
-router.patch(
-    '/stops/:stopId/done',
-    jwtMiddleware,
-    TripCtrl.completeStop as RequestHandler
-);
-
 // Admin routes
 router.get(
     '/admin',
     jwtMiddleware,
     TripCtrl.adminGetTrips as RequestHandler
+);
+router.patch(
+    '/stops/:stopId/done',
+    jwtMiddleware,
+    TripCtrl.completeStop as RequestHandler
+);
+router.get(
+    '/stops/:stopId',
+    jwtMiddleware,
+    TripCtrl.getTripStop as RequestHandler
+);
+router.get(
+    '/:id',
+    jwtMiddleware,
+    TripCtrl.getTripById as RequestHandler
 );
 
 export default router;


### PR DESCRIPTION
## Summary
- add database helpers to load a trip and individual stop along with store details
- expose new controller handlers and secure GET routes for trip and trip stop detail lookups
- cover the new endpoints with controller and router unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb33a07f48330808d5af64557f1b0