### PR TITLE
Refactor StoreSearchMap to require manual store saves

### DIFF
--- a/shopping-taxi-app/src/app/components2/StoreSearchMap.tsx
+++ b/shopping-taxi-app/src/app/components2/StoreSearchMap.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { GoogleMap, Marker, useLoadScript } from '@react-google-maps/api';
 import { useCallback, useState } from 'react';
+import { AxiosError } from 'axios';
 import apiClient from '@/app/services/apiClient';
 
 const containerStyle = { width: '100%', height: '400px' };
@@ -23,6 +24,7 @@ export default function StoreSearchMap() {
     lng: 0,
   });
   const [markers, setMarkers] = useState<MarkerInfo[]>([]);
+  const [saveStatus, setSaveStatus] = useState<Record<string, 'idle' | 'saving' | 'saved' | 'error'>>({});
 
   const handleMapLoad = useCallback((map: google.maps.Map) => {
     if (navigator.geolocation) {
@@ -52,13 +54,14 @@ export default function StoreSearchMap() {
                 name: r.name || 'Store',
               }));
             setMarkers(newMarkers);
-            newMarkers.forEach(m => {
-              apiClient.post('/stores', {
-                name: m.name,
-                address: m.name,
-                latitude: m.position.lat,
-                longitude: m.position.lng
-              }).catch(() => {});
+            setSaveStatus((prev) => {
+              const updatedStatuses: Record<string, 'idle' | 'saving' | 'saved' | 'error'> = {};
+
+              newMarkers.forEach((marker) => {
+                updatedStatuses[marker.id] = prev[marker.id] || 'idle';
+              });
+
+              return updatedStatuses;
             });
           }
         );
@@ -66,20 +69,84 @@ export default function StoreSearchMap() {
     }
   }, []);
 
+  const handleSaveStore = useCallback(async (marker: MarkerInfo) => {
+    const currentStatus = saveStatus[marker.id];
+    if (currentStatus === 'saving' || currentStatus === 'saved') {
+      return;
+    }
+
+    setSaveStatus((prev) => ({ ...prev, [marker.id]: 'saving' }));
+
+    try {
+      await apiClient.post('/stores', {
+        name: marker.name,
+        address: marker.name,
+        latitude: marker.position.lat,
+        longitude: marker.position.lng,
+      });
+      setSaveStatus((prev) => ({ ...prev, [marker.id]: 'saved' }));
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response?.status === 409) {
+        setSaveStatus((prev) => ({ ...prev, [marker.id]: 'saved' }));
+        return;
+      }
+
+      setSaveStatus((prev) => ({ ...prev, [marker.id]: 'error' }));
+    }
+  }, [saveStatus]);
+
   if (loadError) return <p>Map failed to load</p>;
   if (!isLoaded) return <p>Loading map…</p>;
 
   return (
-    <GoogleMap
-      mapContainerStyle={containerStyle}
-      center={center}
-      zoom={13}
-      onLoad={handleMapLoad}
-    >
-      {markers.map((m) => (
-        <Marker key={m.id} position={m.position} title={m.name} />
-      ))}
-    </GoogleMap>
+    <div className="space-y-4">
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={center}
+        zoom={13}
+        onLoad={handleMapLoad}
+      >
+        {markers.map((m) => (
+          <Marker key={m.id} position={m.position} title={m.name} />
+        ))}
+      </GoogleMap>
+
+      {markers.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">Nearby stores</h2>
+          {markers.map((marker) => {
+            const status = saveStatus[marker.id] || 'idle';
+            const isSaving = status === 'saving';
+            const isSaved = status === 'saved';
+            const isError = status === 'error';
+
+            return (
+              <div
+                key={marker.id}
+                className="flex items-center justify-between rounded border border-gray-200 p-3"
+              >
+                <span>{marker.name}</span>
+                <div className="flex items-center gap-2">
+                  {isError && <span className="text-sm text-red-600">Failed to save</span>}
+                  {isSaved && !isError && (
+                    <span className="text-sm text-green-600">Saved</span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleSaveStore(marker)}
+                    disabled={isSaving || isSaved}
+                    className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-blue-300"
+                  >
+                    {isSaving ? 'Saving…' : isSaved ? 'Saved' : 'Save store'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove automatic store creation in the map search callback
- add a visible list of nearby stores with an explicit Save button
- prevent duplicate saves by disabling already saved entries and accepting 409 responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d58dfc81ec8330ba529509aa6d35d6