### PR TITLE
Add socket origin helper for driver and admin live maps

### DIFF
--- a/shopping-taxi-app/README.md
+++ b/shopping-taxi-app/README.md
@@ -84,6 +84,14 @@ Configuration & Utilities
 
 Environment variables are loaded via dotenv (config.ts, jwtConfig.ts).
 
+### Socket configuration
+
+- `NEXT_PUBLIC_API_URL` (e.g., `http://localhost:5001/api`) continues to point to the REST API base path.
+- `NEXT_PUBLIC_SOCKET_URL` is optional. When set, the frontend Socket.IO clients connect to this origin (e.g., `http://localhost:5001`).
+- If `NEXT_PUBLIC_SOCKET_URL` is not provided, the clients derive the socket origin from `NEXT_PUBLIC_API_URL` by stripping any trailing `/api` segment.
+
+Both the driver trip tracker and the admin live map now share this configuration helper to ensure they reach the Socket.IO server at `/socket.io` while leaving REST calls on the existing Axios client.
+
 parseJwt and isTokenExpired utilities handle token parsing and expiry checks.
 
 Pointers for Learning Next

--- a/shopping-taxi-app/src/app/Frontend/Admin/MapReady/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Admin/MapReady/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import io from 'socket.io-client';
 import GoogleMap from '@/app/components2/GoogleMap';
+import { SOCKET_URL } from '@/app/services/socketConfig';
 
 export default function AdminMapLive() {
   const params = useSearchParams();
@@ -11,7 +12,7 @@ export default function AdminMapLive() {
   const [coords, setCoords] = useState<[number,number][]>([]);
 
   useEffect(() => {
-    const s = io(process.env.NEXT_PUBLIC_API_URL!);
+    const s = io(SOCKET_URL, { path: '/socket.io' });
     s.emit('joinTrip', tripId);
     s.on('locationUpdate', ({ lat, lng }: { lat: number; lng: number }) => {
       setCoords(prev => [...prev, [lat, lng]]);

--- a/shopping-taxi-app/src/app/Frontend/Driver/Trip/[id]/page.tsx
+++ b/shopping-taxi-app/src/app/Frontend/Driver/Trip/[id]/page.tsx
@@ -6,6 +6,7 @@ import io from 'socket.io-client';
 import { useParams } from 'next/navigation';
 import apiClient from '@/app/services/apiClient';
 import GoogleMap from '@/app/components2/GoogleMap';
+import { SOCKET_URL } from '@/app/services/socketConfig';
 
 export default function DriverTrip() {
   const { id } = useParams();
@@ -18,7 +19,7 @@ export default function DriverTrip() {
 
     // Setup socket
     // Setup socket
-    const s = io(process.env.NEXT_PUBLIC_API_URL!);
+    const s = io(SOCKET_URL, { path: '/socket.io' });
     s.emit('joinTrip', id);
     // Watch geolocation
     const watcher = navigator.geolocation.watchPosition(pos => {

--- a/shopping-taxi-app/src/app/services/socketConfig.ts
+++ b/shopping-taxi-app/src/app/services/socketConfig.ts
@@ -1,0 +1,14 @@
+const rawSocketUrl = process.env.NEXT_PUBLIC_SOCKET_URL;
+const rawApiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5001/api';
+
+const deriveOrigin = (url: string): string => {
+  try {
+    return new URL(url).origin;
+  } catch (error) {
+    return url.replace(/\/$/, '').replace(/\/api$/, '');
+  }
+};
+
+export const SOCKET_URL = rawSocketUrl && rawSocketUrl.length > 0
+  ? rawSocketUrl
+  : deriveOrigin(rawApiUrl);


### PR DESCRIPTION
## Summary
- add a shared socket configuration helper that derives the Socket.IO origin from environment variables
- update the driver trip and admin map pages to reuse the socket origin while keeping REST calls on the existing api client
- document the new optional NEXT_PUBLIC_SOCKET_URL environment variable in the frontend README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc27388860833094a00ee2b09f7324